### PR TITLE
Backport `dsd-fme` to older platforms

### DIFF
--- a/Formula/dsd-fme.rb
+++ b/Formula/dsd-fme.rb
@@ -24,13 +24,41 @@ class DsdFme < Formula
   depends_on "pulseaudio"
   depends_on "socheatsok78/tap/mbelib"
 
+  on_macos do
+    depends_on "llvm@17" if DevelopmentTools.clang_build_version <= 1500
+  end
+
+  fails_with :clang do
+    build 1500
+    cause "Requires C++17"
+  end
+
   patch do
     url "https://raw.githubusercontent.com/socheatsok78/nur/189c36df96de900297a421cdaee23ee91c4548f1/pkgs/dsd-fme/disable_oss_darwin.patch"
     sha256 "c4eeed49f25be28e82aa854e65a342c6a3c043e898172e210ee2b80c323bc3bd"
   end
 
   def install
-    system "cmake", ".", *std_cmake_args
+    args = []
+
+    if OS.mac? && DevelopmentTools.clang_build_version <= 1500
+      llvm = Formula["llvm@17"]
+
+      ENV["CC"] = llvm.opt_bin/"clang"
+      ENV["CXX"] = llvm.opt_bin/"clang++"
+
+      # Avoid ending up with llvm's Cellar path hard coded.
+      ENV["CLANG_FORMAT"] = llvm.opt_bin/"clang-format"
+
+      # When using Homebrew's superenv shims, we need to use HOMEBREW_LIBRARY_PATHS
+      # rather than LDFLAGS for libc++ in order to correctly link to LLVM's libc++.
+      ENV.prepend_path "HOMEBREW_LIBRARY_PATHS", llvm.opt_lib/"c++"
+
+      args << "-DINSIGHTS_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config"
+      args << "-DINSIGHTS_USE_SYSTEM_INCLUDES=OFF"
+    end
+
+    system "cmake", ".", *args, *std_cmake_args
     system "make", "install"
   end
 


### PR DESCRIPTION
Instead of using **Apple Clang 15** on anything before Sequoia, override the build environment using `llvm@17` instead.